### PR TITLE
fix: Corrigir alinhamento dos campos opcionais

### DIFF
--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -159,10 +159,11 @@ export component AppWindow inherits Window {
 
                     // Optional Sections
                     HorizontalLayout {
-                        spacing: 20px;
+                        spacing: 15px;
+                        padding-right: 10px;
                         
                         VerticalLayout {
-                            width: 50%;
+                            width: 48%;
                             spacing: 5px;
                             Text {
                                 text: "Refatoração (Código)";
@@ -178,7 +179,7 @@ export component AppWindow inherits Window {
                         }
 
                         VerticalLayout {
-                            width: 50%;
+                            width: 48%;
                             spacing: 5px;
                             Text {
                                 text: "Orientações";
@@ -195,10 +196,11 @@ export component AppWindow inherits Window {
                     }
 
                     HorizontalLayout {
-                        spacing: 20px;
+                        spacing: 15px;
+                        padding-right: 10px;
                         
                         VerticalLayout {
-                            width: 50%;
+                            width: 48%;
                             spacing: 5px;
                             Text {
                                 text: "Testes";
@@ -214,7 +216,7 @@ export component AppWindow inherits Window {
                         }
 
                         VerticalLayout {
-                            width: 50%;
+                            width: 48%;
                             spacing: 5px;
                             Text {
                                 text: "Formato de Saída";


### PR DESCRIPTION
- Ajustada largura dos campos de 50% para 48%
- Reduzido espacamento entre campos de 20px para 15px
- Adicionado padding-right de 10px nos layouts horizontais
- Campos Orientacoes e Formato de Saida agora alinhados perfeitamente
- Eliminada invasao da barra de rolagem
- Layout mais limpo e organizado